### PR TITLE
Automatic test discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +219,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "log"
@@ -307,6 +322,7 @@ dependencies = [
  "const-gen",
  "env_logger",
  "glob",
+ "itertools",
  "log",
  "ordered-float",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,10 +62,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "cargo-emit"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
 
 [[package]]
 name = "clap"
@@ -98,7 +110,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -112,6 +124,26 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "const-gen"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb4caa28784488578a9aa32e0a33f0543d961345fc25efc3f04243be3fa6299"
+dependencies = [
+ "const-gen-derive",
+]
+
+[[package]]
+name = "const-gen-derive"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28bbf64501318336d17ffb2ea6c28c791f2af3975f2c11205228c29e3a232f89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "env_filter"
@@ -137,6 +169,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +197,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -241,11 +301,48 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 name = "rslox"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "cargo-emit",
  "clap",
+ "const-gen",
  "env_logger",
+ "glob",
  "log",
  "ordered-float",
+ "proc-macro2",
+ "quote",
+ "serde",
  "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.217"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.217"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -253,6 +350,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -282,7 +390,41 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -369,3 +511,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.95"
 cargo-emit = "0.2.1"
 const-gen = "1.6.5"
 glob = "0.3.2"
+itertools = "0.14.0"
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,13 @@ env_logger = "0.11.6"
 log = "0.4.25"
 ordered-float = "4.6.0"
 thiserror = "2.0.11"
+
+[build-dependencies]
+anyhow = "1.0.95"
+cargo-emit = "0.2.1"
+const-gen = "1.6.5"
+glob = "0.3.2"
+proc-macro2 = "1.0.93"
+quote = "1.0.38"
+serde = { version = "1.0.217", features = ["derive"] }
+toml = "0.8.20"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,126 @@
+use anyhow::bail;
+use const_gen::{const_definition, CompileConst};
+use glob::glob;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use serde::Deserialize;
+use std::{
+    env, fs, io,
+    os::unix::ffi::OsStringExt,
+    path::{Path, PathBuf},
+};
+
+#[derive(CompileConst)]
+#[inherit_docs]
+/// A test case
+struct Test {
+    /// The name of the test case
+    name: String,
+    /// Expected outcome of the test case
+    outcome: TestOutcome,
+    /// Source file containing the tested code
+    source: Vec<u8>,
+}
+
+#[derive(Deserialize, Default)]
+/// A test case description file
+struct TestDescription {
+    /// The name of the test case
+    #[serde(default)]
+    name: Option<String>,
+    /// Expected outcome of the test case
+    #[serde(default)]
+    outcome: TestOutcome,
+}
+
+#[derive(CompileConst, Deserialize, Default)]
+#[serde(tag = "type")]
+#[inherit_docs]
+/// Outcome of a test
+enum TestOutcome {
+    /// File runs without problems
+    #[default]
+    Success,
+    /// File fails to run
+    Failure {
+        /// Error message that must be produced
+        message: Option<String>,
+    },
+}
+
+fn main() {
+    // Use the OUT_DIR environment variable to get an
+    // appropriate path.
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("tests.rs");
+
+    // Contstant declarations and type definitions
+    let mut const_declarations = vec![
+        const_definition!(
+            #[derive(Debug)]
+            Test
+        ),
+        const_definition!(
+            #[derive(Debug)]
+            TestOutcome
+        ),
+    ];
+
+    for test in glob("tests/**/*.lox").unwrap() {
+        let test = match fun_name(test) {
+            Ok(test) => test,
+            Err(err) => {
+                cargo_emit::warning!("{}", err);
+                continue;
+            }
+        };
+        let fun_name = format_ident!(
+            "{}",
+            test.name
+                .replace(
+                    |ch| !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9'|'_'),
+                    "_"
+                )
+                .to_lowercase()
+        );
+        let test: TokenStream = test.const_val().parse().unwrap();
+        const_declarations.push(
+            quote! {
+                #[test]
+                fn #fun_name() {
+                    test_impl(#test)
+                }
+            }
+            .to_string(),
+        );
+    }
+
+    fs::write(&dest_path, const_declarations.join("\n")).unwrap();
+}
+
+fn fun_name(source: Result<PathBuf, glob::GlobError>) -> anyhow::Result<Test> {
+    let source = source?;
+
+    let TestDescription { name, outcome } = match fs::read_to_string(&source.with_extension("test"))
+    {
+        Ok(test_description) => toml::from_str(&test_description)?,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => TestDescription::default(),
+        Err(err) => bail!(err),
+    };
+
+    let name = name.unwrap_or_else(|| {
+        source
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned()
+    });
+
+    let source = source.into_os_string().into_vec();
+
+    Ok(Test {
+        name,
+        outcome,
+        source,
+    })
+}

--- a/build.rs
+++ b/build.rs
@@ -72,11 +72,14 @@ fn main() {
         ),
     ];
 
+    // Signal to cargo that changes in the test directory means a rebuild
+    cargo_emit::rerun_if_changed!("./tests");
+
     for test in Iterator::chain(
         // All test description files
-        glob("tests/**/*.test").unwrap().map(handle_test_file),
+        glob("./tests/**/*.test").unwrap().map(handle_test_file),
         // All test source file
-        glob("tests/**/*.lox").unwrap().map(handle_lox_file),
+        glob("./tests/**/*.lox").unwrap().map(handle_lox_file),
     )
     // Removing all files that maps to the same source
     // In particular, this will remove `.lox` files when the `.test` one is already present

--- a/src/rslox/mod.rs
+++ b/src/rslox/mod.rs
@@ -1,6 +1,8 @@
 mod interpreter;
 mod parser;
 mod scanner;
+
+#[cfg(test)]
 mod tests;
 
 use std::{

--- a/src/rslox/tests.rs
+++ b/src/rslox/tests.rs
@@ -48,14 +48,3 @@ fn test_impl(
         (TestOutcome::Failure { message: None }, Err(_)) => (),
     }
 }
-
-#[test]
-fn non_existent_file() {
-    let mut lox = Lox::new();
-    let result = lox.run_file(std::path::Path::new("tests/non-existent.lox"));
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "Could not open file tests/non-existent.lox"
-    );
-}

--- a/src/rslox/tests.rs
+++ b/src/rslox/tests.rs
@@ -1,30 +1,52 @@
-#[cfg(test)]
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
 use crate::rslox::*;
 
-#[test]
-fn hello_world() {
-    let mut lox = Lox::new();
-    lox.run_file(std::path::Path::new("tests/hello-world.lox"))
-        .unwrap();
-}
+// Include generated test code
+include!(concat!(env!("OUT_DIR"), "/tests.rs"));
 
-#[test]
-fn comments() {
-    let mut lox = Lox::new();
-    lox.run_file(std::path::Path::new("tests/comments.lox"))
-        .unwrap();
-}
+fn test_impl(
+    Test {
+        name,
+        outcome: expected,
+        source,
+    }: Test,
+) {
+    let test_file_path = std::path::Path::new(OsStr::from_bytes(&source));
 
-#[test]
-fn unterminated_string() {
     let mut lox = Lox::new();
-    let result = lox.run_file(std::path::Path::new("tests/unterminated-string.lox"));
+    let result = lox.run_file(test_file_path);
 
-    assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "Syntax error: Unterminated string at line 2"
-    );
+    match (expected, result) {
+        (TestOutcome::Success, Ok(())) => (),
+        (TestOutcome::Success, Err(err)) => {
+            panic!(
+                "Test {name} from file {} returned an error, instead of succeding: {err}",
+                test_file_path.display()
+            )
+        }
+        (TestOutcome::Failure { .. }, Ok(())) => {
+            panic!(
+                "Test {name} from file {} succeded, an error was expected.",
+                test_file_path.display()
+            )
+        }
+        (
+            TestOutcome::Failure {
+                message: Some(message),
+            },
+            Err(err),
+        ) => {
+            let err = err.to_string();
+            if message != err {
+                panic!(
+                        "Test {name} from file {} got the wrong error: expected `{message}`, got `{err}`",
+                        test_file_path.display()
+                    )
+            }
+        }
+        (TestOutcome::Failure { message: None }, Err(_)) => (),
+    }
 }
 
 #[test]

--- a/tests/non-existent-file.test
+++ b/tests/non-existent-file.test
@@ -1,0 +1,5 @@
+source="tests/non-existent.lox"
+
+[outcome]
+type="Failure"
+message="Could not open file tests/non-existent.lox"

--- a/tests/syntax-errors.test
+++ b/tests/syntax-errors.test
@@ -1,0 +1,2 @@
+[outcome]
+type="Failure"

--- a/tests/unterminated-comment.test
+++ b/tests/unterminated-comment.test
@@ -1,0 +1,2 @@
+[outcome]
+type="Failure"

--- a/tests/unterminated-string.test
+++ b/tests/unterminated-string.test
@@ -1,0 +1,3 @@
+[outcome]
+type="Failure"
+message="Syntax error: Unterminated string at line 2"


### PR DESCRIPTION
A little add-on that I found useful while working on `dices` and `zicc`. 
Generates test functions from the files in the `tests` directory directly at build time. With this you can just drop the new `.lox` file in the directory, and `cargo test` the new test case.
I found it to be easier than writing new test cases manually